### PR TITLE
Do not error out if target doesn't exist. Add component.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+components
+build

--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+0.0.4 / 2014-05-20 
+==================
+
+ * do not error out if target doesn't exist
+ * added component.json
+
 0.0.3 / 2014-01-13
 ==================
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+build: components index.js
+	@component build --dev
+
+components: component.json
+	@component install --dev
+
+clean:
+	rm -fr build components
 
 test:
 	@./node_modules/.bin/mocha \
@@ -5,4 +13,7 @@ test:
 		--reporter spec \
 		--bail
 
-.PHONY: test
+test-browser: build
+	@./node_modules/.bin/component-test browser
+
+.PHONY: test test-browser

--- a/Readme.md
+++ b/Readme.md
@@ -5,8 +5,18 @@
 
 ## Installation
 
+Using
+
+In the browser (using component): 
+
 ```
-$ npm install delegates
+$ component install matthewmueller/delegates
+```
+
+In node:
+
+```
+$ npm install matthewmueller-delegates
 ```
 
 ## Example
@@ -42,6 +52,24 @@ delegate(proto, 'request')
   .getter('secure')
   .getter('ips')
   .getter('ip')
+```
+
+# Test
+
+Using node:
+
+In the browser;
+
+```
+npm install
+make test-browser
+```
+
+In node:
+
+```
+npm install
+make test
 ```
 
 # License

--- a/component.json
+++ b/component.json
@@ -4,5 +4,8 @@
   "description": "delegate to children",
   "scripts": [
     "index.js"
-  ]
+  ],
+  "development": {
+    "component/assert": "*"
+  }
 }

--- a/component.json
+++ b/component.json
@@ -1,0 +1,8 @@
+{
+  "name": "delegates",
+  "version": "0.0.3",
+  "description": "delegate to children",
+  "scripts": [
+    "index.js"
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ Delegator.prototype.method = function(name){
   this.methods.push(name);
 
   proto[name] = function(){
+    if (!this[target]) return this;
     return this[target][name].apply(this[target], arguments);
   };
 
@@ -68,6 +69,7 @@ Delegator.prototype.getter = function(name){
   this.getters.push(name);
 
   proto.__defineGetter__(name, function(){
+    if (!this[target]) return undefined;
     return this[target][name];
   });
 
@@ -88,6 +90,7 @@ Delegator.prototype.setter = function(name){
   this.setters.push(name);
 
   proto.__defineSetter__(name, function(val){
+    if (!this[target]) return this;
     return this[target][name] = val;
   });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "component-test": "*"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "delegates",
+  "name": "matthewmueller-delegates",
   "version": "0.0.3",
   "repository": "visionmedia/node-delegates",
   "description": "delegate methods and accessors to another property",

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,19 @@ describe('.method(name)', function(){
 
     obj.foo('something').should.equal('something');
   })
+
+  it('should not error out when there is no target', function(){
+    var obj = {};
+
+    delegate(obj, 'request').method('foo');
+
+    try {
+      obj.foo('whatever');
+    } catch (e) {
+      assert(null == e);
+    }
+
+  });
 })
 
 describe('.getter(name)', function(){
@@ -33,6 +46,18 @@ describe('.getter(name)', function(){
 
     obj.type.should.equal('text/html');
   })
+
+  it('should not error out when there is no target', function(){
+    var obj = {};
+    delegate(obj, 'request').getter('type');
+
+    try {
+      assert(undefined == obj.type);
+    } catch (e) {
+      assert(null == e);
+    }
+
+  });
 })
 
 describe('.setter(name)', function(){
@@ -54,6 +79,20 @@ describe('.setter(name)', function(){
     obj.type = 'hey';
     obj.request.type.should.equal('HEY');
   })
+
+  it('should not error out when there is no target', function(){
+    var obj = {};
+    delegate(obj, 'request').setter('type');
+
+    try {
+      obj.type = 'hey';
+      assert(undefined == obj.type);
+      assert(undefined == obj.request);
+    } catch (e) {
+      assert(null == e);
+    }
+
+  });
 })
 
 describe('.access(name)', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,12 @@
 
 var assert = require('assert');
-var delegate = require('..');
+
+try {
+  var delegate = require('..');
+} catch (e) {
+  var delegate = require('delegates');
+}
+
 
 describe('.method(name)', function(){
   it('should delegate methods', function(){
@@ -14,8 +20,7 @@ describe('.method(name)', function(){
     };
 
     delegate(obj, 'request').method('foo');
-
-    obj.foo('something').should.equal('something');
+    assert('something' == obj.foo('something'));
   })
 
   it('should not error out when there is no target', function(){
@@ -43,8 +48,7 @@ describe('.getter(name)', function(){
     }
 
     delegate(obj, 'request').getter('type');
-
-    obj.type.should.equal('text/html');
+    assert('text/html' == obj.type);
   })
 
   it('should not error out when there is no target', function(){
@@ -77,7 +81,7 @@ describe('.setter(name)', function(){
     delegate(obj, 'request').setter('type');
 
     obj.type = 'hey';
-    obj.request.type.should.equal('HEY');
+    assert('HEY' == obj.request.type);
   })
 
   it('should not error out when there is no target', function(){
@@ -112,6 +116,6 @@ describe('.access(name)', function(){
     delegate(obj, 'request').access('type');
 
     obj.type = 'hey';
-    obj.type.should.equal('HEY');
+    assert('HEY' == obj.type);
   })
 })


### PR DESCRIPTION
This is nice to dynamically add delegates (like active targets that may go inactive in the future).

Also added `component.json` for component consumption