### PR TITLE
adding method for creating fluent accessor

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Delegator(proto, target) {
   this.methods = [];
   this.getters = [];
   this.setters = [];
+  this.fluents = [];
 }
 
 /**
@@ -90,6 +91,31 @@ Delegator.prototype.setter = function(name){
   proto.__defineSetter__(name, function(val){
     return this[target][name] = val;
   });
+
+  return this;
+};
+
+/**
+ * Delegator fluent accessor
+ *
+ * @param {String} name
+ * @return {Delegator} self
+ * @api public
+ */
+
+Delegator.prototype.fluent = function (name) {
+  var proto = this.proto;
+  var target = this.target;
+  this.fluents.push(name);
+
+  proto[name] = function(val){
+    if ('undefined' != typeof val) {
+      this[target][name] = val;
+      return this;
+    } else {
+      return this[target][name];
+    }
+  };
 
   return this;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -76,3 +76,19 @@ describe('.access(name)', function(){
     obj.type.should.equal('HEY');
   })
 })
+
+describe('.fluent(name)', function () {
+  it('should delegate in a fluent fashion', function () {
+    var obj = {
+      settings: {
+        env: 'development'
+      }
+    };
+
+    delegate(obj, 'settings').fluent('env');
+
+    obj.env().should.equal('development');
+    obj.env('production').should.equal(obj);
+    obj.settings.env.should.equal('production');
+  })
+})


### PR DESCRIPTION
This allows you to create a getter/setter that uses a fluent api, for example: (using [duo-serve](https://github.com/dominicbarnes/duo-serve) as my example here, since it's what I'm working on that called for this)

``` js
delegate(Server.prototype, "settings")
  .fluent("body")
  .fluent("global")
  .fluent("html")
  .fluent("root")
  .fluent("title");
```

Which will create fluent accessors, rather than built-in getters/setters, enabling this:

``` js
server()
  .body("body.html")
  .html("index.hbs")
  .title("duo-serve");
```
