### PR TITLE
Compile functions for better performance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,13 +120,10 @@ Delegator.prototype.fluent = function (name) {
   return this;
 };
 
+var validName = /^[$A-Z_][0-9A-Z_$]*$/i;
+
 function requiresBoxNotation(propName){
-  if( propName.indexOf('.') !== -1 ) return true;
-  if( propName.indexOf('"') !== -1 ) return true;
-  if( propName.indexOf('\'') !== -1 ) return true;
-  if( propName.indexOf('\\') !== -1 ) return true;
-  if( propName.indexOf('/') !== -1 ) return true;
-  return false;
+  return !validName.test(propName);
 }
 
 function dot(propName){

--- a/index.js
+++ b/index.js
@@ -124,12 +124,14 @@ function requiresBoxNotation(propName){
   if( propName.indexOf('.') !== -1 ) return true;
   if( propName.indexOf('"') !== -1 ) return true;
   if( propName.indexOf('\'') !== -1 ) return true;
+  if( propName.indexOf('\\') !== -1 ) return true;
+  if( propName.indexOf('/') !== -1 ) return true;
   return false;
 }
 
 function dot(propName){
   if(requiresBoxNotation(propName)){
-    propName = propName.replace('"','\\"');
+    propName = propName.replace('\\','\\\\').replace('"','\\"');
     return '["' + propName + '"]';
   }
 

--- a/index.js
+++ b/index.js
@@ -124,6 +124,15 @@ var validName = /^[$A-Z_][0-9A-Z_$]*$/i;
 
 function requiresBoxNotation(propName){
   return !validName.test(propName);
+  /*try {
+    var f = new Function('val','return val.' + propName);
+    var o = {};
+    o[propName] = 'hello';
+    return f(o) == 'hello';
+  }
+  catch(e){
+    return false;
+  }  */
 }
 
 function dot(propName){

--- a/index.js
+++ b/index.js
@@ -120,7 +120,18 @@ Delegator.prototype.fluent = function (name) {
   return this;
 };
 
+function requiresBoxNotation(propName){
+  if( propName.indexOf('.') !== -1 ) return true;
+  if( propName.indexOf('"') !== -1 ) return true;
+  if( propName.indexOf('\'') !== -1 ) return true;
+  return false;
+}
+
 function dot(propName){
-  if(propName.indexOf('.') !== -1) return '["' + propName + '"]';
+  if(requiresBoxNotation(propName)){
+    propName = propName.replace('"','\\"');
+    return '["' + propName + '"]';
+  }
+
   return '.' + propName;
 }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ Delegator.prototype.method = function(name){
   this.methods.push(name);
 
   proto[name] = new Function(
-    "return this." + target + "." + name + ".apply(this." + target + ", arguments);"
+    "return this" + dot(target) + dot(name) + ".apply(this" + dot(target) + ", arguments);"
   );
 
   return this;
@@ -69,7 +69,7 @@ Delegator.prototype.getter = function(name){
   this.getters.push(name);
 
   proto.__defineGetter__(name, new Function(
-    "return this." + target + "." + name +";"
+    "return this" + dot(target) + dot(name) +";"
   ));
 
   return this;
@@ -89,7 +89,7 @@ Delegator.prototype.setter = function(name){
   this.setters.push(name);
 
   proto.__defineSetter__(name, new Function('val',
-    "return this." + target + "." + name + "= val;"
+    "return this" + dot(target) + dot(name) + "= val;"
   ));
 
   return this;
@@ -110,12 +110,17 @@ Delegator.prototype.fluent = function (name) {
 
   proto[name] = new Function('val',
     "if ('undefined' != typeof val) {" +
-      "this." + target + "." + name + " = val;" +
+      "this" + dot(target) + dot(name) + " = val;" +
       "return this;" +
     "} else {" +
-      "return this." + target + "." + name + ";" +
+      "return this" + dot(target) + dot(name) + ";" +
     "}"
   );
 
   return this;
 };
+
+function dot(propName){
+  if(propName.indexOf('.') !== -1) return '["' + propName + '"]';
+  return '.' + propName;
+}

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ Delegator.prototype.method = function(name){
   var target = this.target;
   this.methods.push(name);
 
-  proto[name] = function(){
-    return this[target][name].apply(this[target], arguments);
-  };
+  proto[name] = new Function(
+    "return this." + target + "." + name + ".apply(this." + target + ", arguments);"
+  );
 
   return this;
 };
@@ -68,9 +68,9 @@ Delegator.prototype.getter = function(name){
   var target = this.target;
   this.getters.push(name);
 
-  proto.__defineGetter__(name, function(){
-    return this[target][name];
-  });
+  proto.__defineGetter__(name, new Function(
+    "return this." + target + "." + name +";"
+  ));
 
   return this;
 };
@@ -88,9 +88,9 @@ Delegator.prototype.setter = function(name){
   var target = this.target;
   this.setters.push(name);
 
-  proto.__defineSetter__(name, function(val){
-    return this[target][name] = val;
-  });
+  proto.__defineSetter__(name, new Function('val',
+    "return this." + target + "." + name + "= val;"
+  ));
 
   return this;
 };
@@ -108,14 +108,14 @@ Delegator.prototype.fluent = function (name) {
   var target = this.target;
   this.fluents.push(name);
 
-  proto[name] = function(val){
-    if ('undefined' != typeof val) {
-      this[target][name] = val;
-      return this;
-    } else {
-      return this[target][name];
-    }
-  };
+  proto[name] = new Function('val',
+    "if ('undefined' != typeof val) {" +
+      "this." + target + "." + name + " = val;" +
+      "return this;" +
+    "} else {" +
+      "return this." + target + "." + name + ";" +
+    "}"
+  );
 
   return this;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -127,4 +127,15 @@ describe('handles special characters', function () {
     delegate(obj, 're"quest').getter("ty'pe");
     obj["ty'pe"].should.equal('text');
   })
+
+  it('slashes in property names',function(){
+    var obj = {
+      're\\quest':{
+        "ty/pe" : 'text'
+      }
+    };
+
+    delegate(obj, 're\\quest').getter("ty/pe");
+    obj["ty/pe"].should.equal('text');
+  });
 })

--- a/test/index.js
+++ b/test/index.js
@@ -137,5 +137,21 @@ describe('handles special characters', function () {
 
     delegate(obj, 're\\quest').getter("ty/pe");
     obj["ty/pe"].should.equal('text');
-  });
+  })
+
+  it('reserved words in property names',function(){
+    var obj = {
+      'new':{
+        'finally' : 'fin',
+        'var' : 'v',
+        'true' : true
+      }
+    };
+
+    delegate(obj, 'new').getter('finally').getter('var').getter('true');
+
+    obj.finally.should.equal('fin');
+    obj.var.should.equal('v');
+    obj.true.should.equal(true);
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -116,4 +116,15 @@ describe('handles special characters', function () {
     obj['flu.ent']().should.equal('bar');
     obj['me.thod']().should.equal('hello!');
   })
+
+  it('quotes in the property name',function(){
+    var obj = {
+      're"quest':{
+        "ty'pe" : 'text'
+      }
+    };
+
+    delegate(obj, 're"quest').getter("ty'pe");
+    obj["ty'pe"].should.equal('text');
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -92,3 +92,28 @@ describe('.fluent(name)', function () {
     obj.settings.env.should.equal('production');
   })
 })
+
+describe('handles special characters', function () {
+  it('dots in the property names',function(){
+    var obj = {
+      're.quest': {
+        'ty.pe': 'text',
+        'flu.ent' : 'foo',
+        'me.thod' : function(){
+          return 'hello!';
+        }
+      }
+    };
+
+    delegate(obj, 're.quest').access('ty.pe').fluent('flu.ent').method('me.thod');
+
+    obj['ty.pe'].should.equal('text');
+    obj['ty.pe'] = 'html';
+    obj['ty.pe'].should.equal('html');
+    obj['re.quest']['ty.pe'].should.equal('html');
+    obj['flu.ent']().should.equal('foo');
+    obj['flu.ent']('bar');
+    obj['flu.ent']().should.equal('bar');
+    obj['me.thod']().should.equal('hello!');
+  })
+})


### PR DESCRIPTION
I'm seeing a ~~25%~~ **75%** improvement.

I created a branch with a performance test comparing new and old versions [here](https://github.com/jamestalmage/node-delegates/blob/compile-performance-test/perf.js). Getting it to run is a bit hinky due to circular dependency conflicts (otherwise I would have included in the PR). I don't think you need the performance test long term anyways. Once it's convinced you this is a good way to go, it's done it's job and can be discarded.

**Running the performance test**

```
git clone git@github.com:jamestalmage/node-delegates.git
cd node-delegates
git checkout compile-performance-test
npm install
node perf
```

~~The only problem with my implementation is that it will fail if you use any punctuation in your property names.~~ (fixed) 

``` javascript
delegate.getter('a.b');
//compiles to:
return this.delegate.a.b;
//but should compile to:
return this.delegate['a.b'];
```

**Todo:**
- [x] fix special character compilation
