### PR TITLE
Added delegate.auto

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,11 @@ delegate(proto, 'request')
 Creates a delegator instance used to configure using the `prop` on the given
 `proto` object. (which is usually a prototype)
 
+## Delegate.auto(proto, targetProto, targetProp)
+
+Delegates getters, setters, values, and methods from targetProto to proto.
+Assumes that targetProto objects will exist under proto objects with the key targetProp.
+
 ## Delegate#method(name)
 
 Allows the given method `name` to be accessed on the host.

--- a/index.js
+++ b/index.js
@@ -24,6 +24,42 @@ function Delegator(proto, target) {
 }
 
 /**
+ * Automatically delegate properties
+ * from a target prototype
+ *
+ * @param {Object} proto
+ * @param {object} targetProto
+ * @param {String} targetProp
+ * @api public
+ */
+
+Delegator.auto = function(proto, targetProto, targetProp){
+  var delegator = Delegator(proto, targetProp);
+  var properties = Object.getOwnPropertyNames(targetProto);
+  for (var i = 0; i < properties.length; i++) {
+    var property = properties[i];
+    var descriptor = Object.getOwnPropertyDescriptor(targetProto, property);
+    if (descriptor.get) {
+      delegator.getter(property);
+    }
+    if (descriptor.set) {
+      delegator.setter(property);
+    }
+    if (descriptor.hasOwnProperty('value')) { // could be undefined but writable
+      var value = descriptor.value;
+      if (value instanceof Function) {
+        delegator.method(property);
+      } else {
+        delegator.getter(property);
+      }
+      if (descriptor.writable) {
+        delegator.setter(property);
+      }
+    }
+  }
+};
+
+/**
  * Delegate method `name`.
  *
  * @param {String} name

--- a/test/index.js
+++ b/test/index.js
@@ -92,3 +92,34 @@ describe('.fluent(name)', function () {
     obj.settings.env.should.equal('production');
   })
 })
+
+describe('.auto(proto, targetProto, target)', function(){
+  it('should apply properties', function(){
+    var obj = {
+      settings: {
+        env: 'development'
+      }
+    };
+
+    var setAs = 0;
+
+    Object.defineProperty(obj.settings, 'getter', {
+      get: function(){
+        return this.env;
+      }
+    });
+    Object.defineProperty(obj.settings, 'setter', {
+      set: val => setAs = val
+    });
+    Object.defineProperty(obj.settings, 'constant', { value: 2 });
+
+    delegate.auto(obj, obj.settings, 'settings');
+
+    obj.env.should.equal('development');
+    obj.getter.should.equal('development');
+    obj.setter = 10;
+    setAs.should.equal(10);
+    obj.constant = 5;
+    obj.constant.should.equal(2);
+  })
+})


### PR DESCRIPTION
> Delegates getters, setters, values, and methods from targetProto to proto. Assumes that targetProto objects will exist under proto objects with the key targetProp.

This will be very useful for a lot of projects such as Koa. Even in Koa where we have multiple delegates and in some cases they overlap, you can always use a couple manual delegates after the automatic delegates to resolve the overlaps, as `__defineGetter__` and `__defineSetter__` can override previous properties.